### PR TITLE
Release 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.9.1
+* refactor to unify validation between fees and payments
+* relies on stable versions of all artifacts
+* Number of trustees required for MINT transaction set to 3
+* UTXO cache optimization
+* additional testing
+* bugfixes
+
 ## 0.9.0
 
 * Significant refactoring and updated tests

--- a/sovtoken/sovtoken/__metadata__.py
+++ b/sovtoken/sovtoken/__metadata__.py
@@ -4,7 +4,7 @@ sovtoken package metadata
 
 # TODO: Update the field values below where needed
 __title__ = 'sovtoken'
-__version_info__ = (0, 9, 0)
+__version_info__ = (0, 9, 1)
 __version__ = '.'.join(map(str, __version_info__))
 __description__ = 'Token Plugin For Indy Plenum'
 __long_description__ = ''

--- a/sovtokenfees/sovtokenfees/__metadata__.py
+++ b/sovtokenfees/sovtokenfees/__metadata__.py
@@ -9,7 +9,7 @@ __long_description__ = ''
 __maintainer__ = 'Evernym'
 __title__ = 'sovtokenfees'
 __url__ = 'https://github.com/evernym/plugin/tree/master/sovtokenfees'
-__version_info__ = (0, 9, 0)
+__version_info__ = (0, 9, 1)
 __version__ = '.'.join(map(str, __version_info__))
 
 __all__ = ['__title__',


### PR DESCRIPTION
* refactor to unify validation between fees and payments
* relies on stable versions of all artifacts
* Number of trustees required for MINT transaction set to 3
* UTXO cache optimization
* additional testing
* bugfixes