### PR TITLE
Fix TokenHashStore to use RocksDB instead of LevelDB

### DIFF
--- a/sovtoken/sovtoken/storage.py
+++ b/sovtoken/sovtoken/storage.py
@@ -1,13 +1,13 @@
 from ledger.compact_merkle_tree import CompactMerkleTree
 from plenum.common.ledger import Ledger
 from plenum.persistence.db_hash_store import DbHashStore
-from storage.helper import initKeyValueStorage
+from storage.helper import initKeyValueStorage, initHashStore
 from sovtoken.utxo_cache import UTXOCache
 from state.pruning_state import PruningState
 
 
 def get_token_hash_store(data_dir):
-    return DbHashStore(dataDir=data_dir, fileNamePrefix='sovtoken')
+    return initHashStore(data_dir=data_dir, name='sovtoken')
 
 
 def get_token_ledger(data_dir, name, hash_store, config):


### PR DESCRIPTION
Signed-off-by: Nikita Khateev <nikita.khateev@dsr-corporation.com>