### PR TITLE
TOK-343 Remove unnecessary 3PC handlers

### DIFF
--- a/sovtokenfees/sovtokenfees/main.py
+++ b/sovtokenfees/sovtokenfees/main.py
@@ -58,10 +58,5 @@ def integrate_plugin_in_node(node):
                                       three_pc_handler.add_to_ordered)
     node.master_replica.register_hook(ReplicaHooks.APPLY_PPR,
                                       three_pc_handler.check_recvd_pre_prepare)
-    node.master_replica.register_hook(ReplicaHooks.VALIDATE_PR,
-                                      three_pc_handler.check_recvd_prepare)
-    node.master_replica.register_hook(ReplicaHooks.BATCH_CREATED,
-                                      three_pc_handler.batch_created)
-    node.master_replica.register_hook(ReplicaHooks.BATCH_REJECTED,
-                                      three_pc_handler.batch_rejected)
+
     return node

--- a/sovtokenfees/sovtokenfees/three_phase_commit_handling.py
+++ b/sovtokenfees/sovtokenfees/three_phase_commit_handling.py
@@ -54,10 +54,6 @@ class ThreePhaseCommitHandler:
                 prepare = updateNamedTuple(prepare, **extra)
         return prepare
 
-    def add_to_commit(self, commit):
-        # Nothing needed in commit
-        return commit
-
     # ?
     def add_to_ordered(self, ordered, pre_prepare):
         if pre_prepare.ledgerId != TOKEN_LEDGER_ID and \
@@ -114,25 +110,6 @@ class ThreePhaseCommitHandler:
                                                                 f.TXN_ROOT.nm,
                                                                 self.fees_req_handler.token_ledger.uncommittedRootHash,
                                                                 recvd_txn_root))
-
-    # Checks to make sure the prepare message was properly appended and formatted with fee info
-    def check_recvd_prepare(self, prepare, pre_prepare):
-        # TODO:
-        return
-
-    # Checks to make sure the commit message was properly appended and formatted with fee info
-    def check_recvd_commit(self, commit):
-        # No check needed in commit
-        return
-
-    # ?
-    def batch_created(self, ledger_id, state_root):
-        # Need old state root hash to preserve
-        pass
-
-    # ?
-    def batch_rejected(self, ledger_id):
-        pass
 
     # Makes sure that the "plugins_fields" member is contained in a message. This field is what distinguishes normal
     # messages from messages that support the sovrin plugin


### PR DESCRIPTION
Signed-off-by: Nikita Khateev <nikita.khateev@dsr-corporation.com>

Examined the usage of functions:
1) `add_to_commit`, `check_recvd_commit`  -- no used in any hook.
2) `batch_rejected`, `batch_created` -- used in hooks, but this hooks are not called in plenum. Moreover, do not bring any new functionality.
3) `check_recvd_prepare` -- used in VALIDATE_PR, this hook is executed, but no functionality brought.

Decided to delete them