### PR TITLE
Fix ci

### DIFF
--- a/devops/aws-codebuild/Jenkinsfile.cd
+++ b/devops/aws-codebuild/Jenkinsfile.cd
@@ -1,6 +1,6 @@
 #!groovy
 
-def sovLibrary = library(identifier: 'sovrin-aws-codebuild@v1.0.0', retriever: modernSCM(
+def sovLibrary = library(identifier: 'sovrin-aws-codebuild@v1.0.1', retriever: modernSCM(
     github(credentialsId: 'sovbot-github', repoOwner: 'sovrin-foundation', repository: 'aws-codebuild-pipeline-plugin')
 )).com.sovrin.pipeline
 

--- a/devops/aws-codebuild/Jenkinsfile.ci
+++ b/devops/aws-codebuild/Jenkinsfile.ci
@@ -100,7 +100,7 @@ pipelineWrapper({
                                         allowEmptyArchive = true
                                     }
 
-                                    this.junit "logs/test.${proj}.xml"
+                                    // this.junit "logs/test.${proj}.xml"
                                 }
                             }
                         }

--- a/devops/aws-codebuild/Jenkinsfile.ci
+++ b/devops/aws-codebuild/Jenkinsfile.ci
@@ -1,6 +1,6 @@
 #!groovy
 
-def sovLibrary = library(identifier: 'sovrin-aws-codebuild@v1.0.0', retriever: modernSCM(
+def sovLibrary = library(identifier: 'sovrin-aws-codebuild@v1.0.1', retriever: modernSCM(
     github(credentialsId: 'sovbot-github', repoOwner: 'sovrin-foundation', repository: 'aws-codebuild-pipeline-plugin')
 )).com.sovrin.pipeline
 


### PR DESCRIPTION
- disable junit until mature solution is found (currently it fails because of too big xml that contains all logs including TRACE message)
- bumps version of jenkins library to 1.0.1 which includes some fixes for artifacts routine