### PR TITLE
ST-618:  use correct parent class for Authenticators 

### DIFF
--- a/devops/docker/ci/xenial/Dockerfile
+++ b/devops/docker/ci/xenial/Dockerfile
@@ -25,8 +25,8 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88 \
 RUN add-apt-repository "deb https://repo.sovrin.org/sdk/deb xenial master" \
     && apt-get update && apt-get install -y \
         libindy-crypto=0.4.5 \
-        libindy=1.9.0~1132 \
-        libsovtoken=0.9.7~66 \
+        libindy=1.10.1~1220 \
+        libsovtoken=1.0.0~79 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /etc/indy && echo "ENABLED_PLUGINS = ['sovtoken', 'sovtokenfees']" > /etc/indy/indy_config.py \

--- a/sovtoken/setup.py
+++ b/sovtoken/setup.py
@@ -19,7 +19,7 @@ metadata = {}
 with open(os.path.join(here, 'sovtoken', '__metadata__.py'), 'r') as f:
     exec(f.read(), metadata)
 
-tests_require = ['pytest==4.6.2', 'pytest-xdist', 'mock', 'python3-indy==1.10.0-dev-1198']
+tests_require = ['pytest==4.6.2', 'pytest-xdist', 'mock', 'python3-indy==1.10.1-dev-1220']
 
 setup(
     name=metadata['__title__'],

--- a/sovtoken/sovtoken/client_authnr.py
+++ b/sovtoken/sovtoken/client_authnr.py
@@ -1,16 +1,13 @@
-from copy import deepcopy
-
 import base58
 from base58 import b58decode
 
 from common.serializers.serialization import serialize_msg_for_signing
-from plenum.common.constants import TXN_TYPE, IDENTIFIER
-from plenum.common.exceptions import (CouldNotAuthenticate,
-                                      InsufficientCorrectSignatures,
+from indy_node.server.client_authn import LedgerBasedAuthNr
+from plenum.common.constants import TXN_TYPE
+from plenum.common.exceptions import (InsufficientCorrectSignatures,
                                       InvalidSignatureFormat)
 from plenum.common.types import OPERATION, PLUGIN_TYPE_AUTHENTICATOR, f
 from plenum.common.verifier import DidVerifier, Verifier
-from plenum.server.client_authn import CoreAuthNr
 from sovtoken.constants import (ADDRESS, INPUTS, MINT_PUBLIC, OUTPUTS, SIGS,
                                 XFER_PUBLIC, EXTRA)
 from sovtoken.util import address_to_verkey
@@ -26,7 +23,7 @@ class AddressSigVerifier(Verifier):
         return self._vr.verify(sig, msg)
 
 
-class TokenAuthNr(CoreAuthNr):
+class TokenAuthNr(LedgerBasedAuthNr):
     pluginType = PLUGIN_TYPE_AUTHENTICATOR
 
     # ------------------------------------------------------------------------------------

--- a/sovtoken/sovtoken/main.py
+++ b/sovtoken/sovtoken/main.py
@@ -100,5 +100,5 @@ def register_authentication(node):
     token_authnr = TokenAuthNr(ACCEPTABLE_WRITE_TYPES,
                                ACCEPTABLE_QUERY_TYPES,
                                ACCEPTABLE_ACTION_TYPES,
-                               node.states[DOMAIN_LEDGER_ID])
+                               node.db_manager.idr_cache)
     node.clientAuthNr.register_authenticator(token_authnr)

--- a/sovtoken/sovtoken/test/helpers/helper_request.py
+++ b/sovtoken/sovtoken/test/helpers/helper_request.py
@@ -92,7 +92,7 @@ class HelperRequest():
         extra = self._looper.loop.run_until_complete(extra_future)
         return extra
 
-    def mint(self, outputs, text=None, mechanism=None, version=None):
+    def mint(self, outputs, text=None, mechanism=None, version=None, number_signers=3):
         """ Builds a mint request. """
         outputs_ready = self._prepare_outputs(outputs)
 
@@ -100,7 +100,7 @@ class HelperRequest():
         mint_request = self._looper.loop.run_until_complete(mint_request_future)[0]
         if text and mechanism and version:
             mint_request = self.add_transaction_author_agreement_to_request(mint_request, text, mechanism, version)
-        mint_request = self._wallet.sign_request_trustees(mint_request, number_signers=3)
+        mint_request = self._wallet.sign_request_trustees(mint_request, number_signers=number_signers)
         mint_request = json.loads(mint_request)
         signatures = mint_request["signatures"]
         mint_request = self._sdk.sdk_json_to_request_object(mint_request)

--- a/sovtoken/sovtoken/test/test_client_authnr.py
+++ b/sovtoken/sovtoken/test/test_client_authnr.py
@@ -8,10 +8,8 @@ from sovtoken.test.helpers.helper_general import utxo_from_addr_and_seq_no
 from sovtoken.test.helpers.helper_request import SEC_PER_DAY
 
 from indy_common.types import Request
-from plenum.common.constants import DOMAIN_LEDGER_ID
-from plenum.common.exceptions import UnknownIdentifier, InvalidSignatureFormat, InsufficientCorrectSignatures, \
-    CouldNotAuthenticate
-from plenum.server.client_authn import CoreAuthNr
+from indy_node.server.client_authn import LedgerBasedAuthNr
+from plenum.common.exceptions import UnknownIdentifier, InvalidSignatureFormat, InsufficientCorrectSignatures
 from sovtoken.test.wallet import TokenWallet
 from sovtoken.client_authnr import TokenAuthNr, AddressSigVerifier
 from sovtoken.constants import INPUTS, OUTPUTS, EXTRA, ACCEPTABLE_WRITE_TYPES, ACCEPTABLE_QUERY_TYPES, \
@@ -118,7 +116,7 @@ def test_authenticate_invalid_signatures_format(helpers, node, addresses):
     token_authnr = TokenAuthNr(ACCEPTABLE_WRITE_TYPES,
                                ACCEPTABLE_QUERY_TYPES,
                                ACCEPTABLE_ACTION_TYPES,
-                               node[0].states[DOMAIN_LEDGER_ID])
+                               node[0].db_manager.idr_cache)
     outputs = [{"address": SF_address, "amount": 30}, {"address": user1_address, "amount": 30}]
     request = helpers.request.mint(outputs)
     req_data = request.as_dict
@@ -137,7 +135,7 @@ def test_authenticate_insufficient_valid_signatures_data(helpers, node, addresse
     token_authnr = TokenAuthNr(ACCEPTABLE_WRITE_TYPES,
                                ACCEPTABLE_QUERY_TYPES,
                                ACCEPTABLE_ACTION_TYPES,
-                               node[0].states[DOMAIN_LEDGER_ID])
+                               node[0].db_manager.idr_cache)
     outputs = [{"address": SF_address, "amount": 30}, {"address": user1_address, "amount": 30}]
     request = helpers.request.mint(outputs)
     req_data = request.as_dict
@@ -153,7 +151,7 @@ def test_authenticate_success_3_sigs(helpers, node, addresses):
     token_authnr = TokenAuthNr(ACCEPTABLE_WRITE_TYPES,
                                ACCEPTABLE_QUERY_TYPES,
                                ACCEPTABLE_ACTION_TYPES,
-                               node[0].states[DOMAIN_LEDGER_ID])
+                               node[0].db_manager.idr_cache)
     outputs = [{"address": SF_address, "amount": 30}, {"address": user1_address, "amount": 30}]
     request = helpers.request.mint(outputs)
     req_data = request.as_dict
@@ -167,7 +165,7 @@ def test_authenticate_calls_authenticate_xfer(helpers, node, addresses):
     token_authnr = TokenAuthNr(ACCEPTABLE_WRITE_TYPES,
                                ACCEPTABLE_QUERY_TYPES,
                                ACCEPTABLE_ACTION_TYPES,
-                               node[0].states[DOMAIN_LEDGER_ID])
+                               node[0].db_manager.idr_cache)
     inputs = [{"source": utxo_from_addr_and_seq_no(SF_address, 1)}]
     outputs = [{"address": user1_address, "amount": 10}, {"address": SF_address, "amount": 10}]
     request = helpers.request.transfer(inputs, outputs)
@@ -185,7 +183,7 @@ def test_authenticate_xfer_success(node, user2_token_wallet, user2_address, user
     token_authnr = TokenAuthNr(ACCEPTABLE_WRITE_TYPES,
                                ACCEPTABLE_QUERY_TYPES,
                                ACCEPTABLE_ACTION_TYPES,
-                               node[0].states[DOMAIN_LEDGER_ID])
+                               node[0].db_manager.idr_cache)
     inputs = [[user2_token_wallet, user2_address, 1]]
     outputs = [{"address": user1_address, "amount": 10}, {"address": user2_address, "amount": 10}]
     request = xfer_request(inputs, outputs)
@@ -199,7 +197,7 @@ def test_authenticate_xfer_invalid_signature_format(node, user2_token_wallet, us
     token_authnr = TokenAuthNr(ACCEPTABLE_WRITE_TYPES,
                                ACCEPTABLE_QUERY_TYPES,
                                ACCEPTABLE_ACTION_TYPES,
-                               node[0].states[DOMAIN_LEDGER_ID])
+                               node[0].db_manager.idr_cache)
     inputs = [[user2_token_wallet, user2_address, 1]]
     outputs = [[user1_address, 10], [user2_address, 10]]
     request = xfer_request(inputs, outputs)
@@ -215,7 +213,7 @@ def test_authenticate_xfer_insufficient_correct_signatures(node, user2_token_wal
     token_authnr = TokenAuthNr(ACCEPTABLE_WRITE_TYPES,
                                ACCEPTABLE_QUERY_TYPES,
                                ACCEPTABLE_ACTION_TYPES,
-                               node[0].states[DOMAIN_LEDGER_ID])
+                               node[0].db_manager.idr_cache)
     inputs = [[user2_token_wallet, user2_address, 1], [SF_token_wallet, SF_address, 2]]
     outputs = [[user1_address, 10], [user2_address, 10]]
     request = xfer_request(inputs, outputs)
@@ -232,7 +230,7 @@ def test_authenticate_xfer_with_extra(helpers, node, addresses):
     token_authnr = TokenAuthNr(ACCEPTABLE_WRITE_TYPES,
                                ACCEPTABLE_QUERY_TYPES,
                                ACCEPTABLE_ACTION_TYPES,
-                               node[0].states[DOMAIN_LEDGER_ID])
+                               node[0].db_manager.idr_cache)
     inputs = [{"source": utxo_from_addr_and_seq_no(SF_address, 1)}]
     outputs = [{"address": user1_address, "amount": 10}, {"address": SF_address, "amount": 10}]
     request = helpers.request.transfer(inputs, outputs, extra=json.dumps({"aaa": "bbb"}))
@@ -246,7 +244,7 @@ def test_authenticate_xfer_with_extra_not_signed(helpers, node, addresses):
     token_authnr = TokenAuthNr(ACCEPTABLE_WRITE_TYPES,
                                ACCEPTABLE_QUERY_TYPES,
                                ACCEPTABLE_ACTION_TYPES,
-                               node[0].states[DOMAIN_LEDGER_ID])
+                               node[0].db_manager.idr_cache)
     inputs = [{"source": utxo_from_addr_and_seq_no(SF_address, 1)}]
     outputs = [{"address": user1_address, "amount": 10}, {"address": SF_address, "amount": 10}]
     request = helpers.request.transfer(inputs, outputs)
@@ -262,7 +260,7 @@ def test_authenticate_xfer_with_taa(helpers, node, addresses):
     token_authnr = TokenAuthNr(ACCEPTABLE_WRITE_TYPES,
                                ACCEPTABLE_QUERY_TYPES,
                                ACCEPTABLE_ACTION_TYPES,
-                               node[0].states[DOMAIN_LEDGER_ID])
+                               node[0].db_manager.idr_cache)
     inputs = [{"source": utxo_from_addr_and_seq_no(SF_address, 1)}]
     outputs = [{"address": user1_address, "amount": 10}, {"address": SF_address, "amount": 10}]
     extra = helpers.request.add_transaction_author_agreement_to_extra(None, "text", "mechanism", "version")
@@ -276,7 +274,7 @@ def test_authenticate_xfer_with_taa_not_signed(helpers, node, addresses, looper)
     token_authnr = TokenAuthNr(ACCEPTABLE_WRITE_TYPES,
                                ACCEPTABLE_QUERY_TYPES,
                                ACCEPTABLE_ACTION_TYPES,
-                               node[0].states[DOMAIN_LEDGER_ID])
+                               node[0].db_manager.idr_cache)
     inputs = [{"source": utxo_from_addr_and_seq_no(SF_address, 1)}]
     outputs = [{"address": user1_address, "amount": 10}, {"address": SF_address, "amount": 10}]
     request = helpers.request.transfer(inputs, outputs)
@@ -295,13 +293,13 @@ def test_authenticate_xfer_with_taa_not_signed(helpers, node, addresses, looper)
 # -------------------------Test serializeForSig method------------------------------------------------------------------
 
 # This test that the serializeForSig method is being called when a XFER_PUBLIC request is submitted
-@mock.patch.object(CoreAuthNr, 'serializeForSig', return_value=True)
+@mock.patch.object(LedgerBasedAuthNr, 'serializeForSig', return_value=True)
 def test_serializeForSig_XFER_PUBLIC_path(node, user2_token_wallet, user2_address,
                                           SF_token_wallet, SF_address, user1_address):
     token_authnr = TokenAuthNr(ACCEPTABLE_WRITE_TYPES,
                                ACCEPTABLE_QUERY_TYPES,
                                ACCEPTABLE_ACTION_TYPES,
-                               node[0].states[DOMAIN_LEDGER_ID])
+                               node[0].db_manager.idr_cache)
     inputs = [[user2_token_wallet, user2_address, 1], [SF_token_wallet, SF_address, 2]]
     outputs = [[user1_address, 10], [user1_address, 10]]
     request = xfer_request(inputs, outputs)
@@ -311,13 +309,13 @@ def test_serializeForSig_XFER_PUBLIC_path(node, user2_token_wallet, user2_addres
 
 
 # This test that the serializeForSig method is being called when a MINT_PUBLIC request is submitted
-@mock.patch.object(CoreAuthNr, 'serializeForSig')
+@mock.patch.object(LedgerBasedAuthNr, 'serializeForSig')
 def test_serializeForSig_MINT_PUBLIC_path(helpers, node, addresses):
     [SF_address, user1_address] = addresses
     token_authnr = TokenAuthNr(ACCEPTABLE_WRITE_TYPES,
                                ACCEPTABLE_QUERY_TYPES,
                                ACCEPTABLE_ACTION_TYPES,
-                               node[0].states[DOMAIN_LEDGER_ID])
+                               node[0].db_manager.idr_cache)
     outputs = [[SF_address, 30], [user1_address, 30]]
     request = helpers.request.mint(outputs)
     msg = request.as_dict
@@ -333,7 +331,7 @@ def test_getVerkey_success(node):
     token_authnr = TokenAuthNr(ACCEPTABLE_WRITE_TYPES,
                                ACCEPTABLE_QUERY_TYPES,
                                ACCEPTABLE_ACTION_TYPES,
-                               node[0].states[DOMAIN_LEDGER_ID])
+                               node[0].db_manager.idr_cache)
     ver_key = token_authnr.getVerkey(VALID_IDENTIFIER, Request())
     assert len(ver_key) == 23
     assert ver_key[0] == '~'
@@ -344,7 +342,7 @@ def test_getVerkey_pay_address_success(node):
     token_authnr = TokenAuthNr(ACCEPTABLE_WRITE_TYPES,
                                ACCEPTABLE_QUERY_TYPES,
                                ACCEPTABLE_ACTION_TYPES,
-                               node[0].states[DOMAIN_LEDGER_ID])
+                               node[0].db_manager.idr_cache)
     # TODO change these to indicate they are addresses
     identifier_43 = 'sjw1ceG7wtym3VcnyaYtf1xo37gCUQHDR5VWcKWNPLRZ1X8eC'
     ver_key = token_authnr.getVerkey(identifier_43, Request())
@@ -356,7 +354,7 @@ def test_getVerkey_invalid_identifier(node):
     token_authnr = TokenAuthNr(ACCEPTABLE_WRITE_TYPES,
                                ACCEPTABLE_QUERY_TYPES,
                                ACCEPTABLE_ACTION_TYPES,
-                               node[0].states[DOMAIN_LEDGER_ID])
+                               node[0].db_manager.idr_cache)
     identifier_invalid = 'INVALID_IDENTIFIER'
     with pytest.raises(UnknownIdentifier):
         token_authnr.getVerkey(identifier_invalid, Request())
@@ -370,7 +368,7 @@ def test_get_xfer_ser_data_success(node, user2_token_wallet, user2_address,
     token_authnr = TokenAuthNr(ACCEPTABLE_WRITE_TYPES,
                                ACCEPTABLE_QUERY_TYPES,
                                ACCEPTABLE_ACTION_TYPES,
-                               node[0].states[DOMAIN_LEDGER_ID])
+                               node[0].db_manager.idr_cache)
     inputs = [[user2_token_wallet, user2_address, 1], [SF_token_wallet, SF_address, 2]]
     outputs = [[user1_address, 10], [user1_address, 10]]
     request = xfer_request(inputs, outputs)

--- a/sovtokenfees/setup.py
+++ b/sovtokenfees/setup.py
@@ -18,7 +18,7 @@ metadata={}
 with open(os.path.join(here, 'sovtokenfees', '__metadata__.py'), 'r') as f:
     exec(f.read(), metadata)
 
-tests_require = ['pytest==4.6.2', 'pytest-xdist', 'python3-indy==1.10.0-dev-1198']
+tests_require = ['pytest==4.6.2', 'pytest-xdist', 'python3-indy==1.10.1-dev-1220']
 
 setup(
 

--- a/sovtokenfees/sovtokenfees/client_authnr.py
+++ b/sovtokenfees/sovtokenfees/client_authnr.py
@@ -1,17 +1,17 @@
+from indy_node.server.client_authn import LedgerBasedAuthNr
 from plenum.common.constants import TXN_TYPE
 from plenum.common.exceptions import InvalidClientRequest
 from plenum.common.types import PLUGIN_TYPE_AUTHENTICATOR, OPERATION, f
 from plenum.common.verifier import DidVerifier
-from plenum.server.client_authn import CoreAuthNr
-from sovtokenfees.constants import SET_FEES, GET_FEE, GET_FEES
+from sovtokenfees.constants import SET_FEES
 from sovtoken.client_authnr import AddressSigVerifier, TokenAuthNr
 
 
-class FeesAuthNr(CoreAuthNr):
+class FeesAuthNr(LedgerBasedAuthNr):
     pluginType = PLUGIN_TYPE_AUTHENTICATOR
 
-    def __init__(self, write_types, query_types, action_types, state, token_authnr):
-        super().__init__(write_types, query_types, action_types, state)
+    def __init__(self, write_types, query_types, action_types, cache, token_authnr):
+        super().__init__(write_types, query_types, action_types, cache)
         self.token_authnr = token_authnr
 
     def authenticate(self, req_data, identifier: str = None,

--- a/sovtokenfees/sovtokenfees/main.py
+++ b/sovtokenfees/sovtokenfees/main.py
@@ -122,7 +122,7 @@ def register_authentication(node):
         raise ImportError('sovtoken plugin should be loaded, '  # noqa
                           'authenticator not found')
     fees_authnr = FeesAuthNr(ACCEPTABLE_WRITE_TYPES_FEE, ACCEPTABLE_QUERY_TYPES_FEE, ACCEPTABLE_ACTION_TYPES_FEE,
-                             node.getState(DOMAIN_LEDGER_ID), token_authnr)
+                             node.db_manager.idr_cache, token_authnr)
     node.clientAuthNr.register_authenticator(fees_authnr)
     fees_authorizer = FeesAuthorizer(config_state=node.getState(CONFIG_LEDGER_ID),
                                      utxo_cache=utxo_cache)

--- a/sovtokenfees/sovtokenfees/test/conftest.py
+++ b/sovtokenfees/sovtokenfees/test/conftest.py
@@ -86,7 +86,6 @@ class IOAddressesStatic(IOAddresses):
 # ######################
 # configuration fixtures
 # ######################
-8
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
- `TokenAuthNr` and `FeesAuthNr` extend LedgerBasedAuthNr, not CoreAuthNr now
- bumped libindy and libsovtoken