### PR TITLE
fixed deb depends on version

### DIFF
--- a/.github/workflows/reuseable_build_package.yaml
+++ b/.github/workflows/reuseable_build_package.yaml
@@ -38,11 +38,17 @@ jobs:
       - name: Set Version with UX-timestamp
         if: ${{ inputs.isDev }}
         run: python3 updateVersion.py --timestamp ${{ needs.timestamp.outputs.timestamp }}
+      - name: Get indy-node version to depend on
+        id: node-version
+        run: |
+          version=$(grep -oP "\d+.\d+.\d+((-|.)?rc\d+)?" <<< $(grep -oP "indy-node==\d+.\d+.\d+((-|.)?rc\d+)?" sovtokenfees/setup.py) || true)
+          echo $version > indy-node-version.txt
+          echo "::set-output name=nodeVersion::$(sed 's/\./\~/3' indy-node-version.txt)"
       - name: Build Token Plugin deployment package
         run: |
           mkdir -p /tmp/build-output
-          fpm  --input-type dir --output-type deb --name sovtoken  --version $(./updateVersion.py --getVersion) --depends "indy-node(=1.13.0~dev1654534721)" --verbose --no-python-dependencies --force  sovtoken/
-          fpm  --input-type dir --output-type deb --name sovtokenfees  --version $(./updateVersion.py --getVersion) --depends "indy-node(=1.13.0~dev1654534721)" --verbose --no-python-dependencies --force  sovtokenfees/
+          fpm  --input-type dir --output-type deb --name sovtoken  --version $(./updateVersion.py --getVersion) --depends "indy-node(=${{ steps.node-version.outputs-nodeVersion }})" --verbose --no-python-dependencies --force  sovtoken/
+          fpm  --input-type dir --output-type deb --name sovtokenfees  --version $(./updateVersion.py --getVersion) --depends "indy-node(=${{ steps.node-version.outputs-nodeVersion }})" --verbose --no-python-dependencies --force  sovtokenfees/
           mv ./*.deb /tmp/build-output
       - name: Upload sovtoken-deb
         uses: actions/upload-artifact@v2

--- a/.github/workflows/reuseable_build_package.yaml
+++ b/.github/workflows/reuseable_build_package.yaml
@@ -40,6 +40,7 @@ jobs:
         run: python3 updateVersion.py --timestamp ${{ needs.timestamp.outputs.timestamp }}
       - name: Get indy-node version to depend on
         id: node-version
+        shell: bash
         run: |
           version=$(grep -oP "\d+.\d+.\d+((-|.)?rc\d+)?" <<< $(grep -oP "indy-node==\d+.\d+.\d+((-|.)?rc\d+)?" sovtokenfees/setup.py) || true)
           echo $version > indy-node-version.txt
@@ -47,8 +48,8 @@ jobs:
       - name: Build Token Plugin deployment package
         run: |
           mkdir -p /tmp/build-output
-          fpm  --input-type dir --output-type deb --name sovtoken  --version $(./updateVersion.py --getVersion) --depends "indy-node(=${{ steps.node-version.outputs-nodeVersion }})" --verbose --no-python-dependencies --force  sovtoken/
-          fpm  --input-type dir --output-type deb --name sovtokenfees  --version $(./updateVersion.py --getVersion) --depends "indy-node(=${{ steps.node-version.outputs-nodeVersion }})" --verbose --no-python-dependencies --force  sovtokenfees/
+          fpm  --input-type dir --output-type deb --name sovtoken  --version $(./updateVersion.py --getVersion) --depends "indy-node(=${{ steps.node-version.outputs.nodeVersion }})" --verbose --no-python-dependencies --force  sovtoken/
+          fpm  --input-type dir --output-type deb --name sovtokenfees  --version $(./updateVersion.py --getVersion) --depends "indy-node(=${{ steps.node-version.outputs.nodeVersion }})" --verbose --no-python-dependencies --force  sovtokenfees/
           mv ./*.deb /tmp/build-output
       - name: Upload sovtoken-deb
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Deb package now depends on the same version of indy-node set in `setup.py`

Signed-off-by: pSchlarb <p.schlarb@esatus.com>