### PR TITLE
Update indy-node dependency to 1.13.2-rc5

### DIFF
--- a/.github/workflows/reuseable_build_package.yaml
+++ b/.github/workflows/reuseable_build_package.yaml
@@ -59,8 +59,47 @@ jobs:
       - name: Build Token Plugin deployment package
         run: |
           mkdir -p /tmp/build-output
-          fpm  --input-type dir --output-type deb --name sovtoken --architecture amd64 --maintainer "Sovrin" --no-python-fix-name  --version ${{ steps.version.outputs.debVersion }} --depends "indy-node(=${{ steps.node-version.outputs.nodeVersion }})" --verbose --no-python-dependencies --after-install ./devops/build-scripts/focal/sovtoken/postinst --before-remove ./devops/build-scripts/focal/sovtoken/prerm --exclude "*.pyo" --exclude "*.pyc" --no-python-fix-dependencies --python-bin "/usr/bin/python3" --force  sovtoken/
-          fpm  --input-type dir --output-type deb --name sovtokenfees --architecture amd64 --maintainer "Sovrin" --no-python-fix-name  --version ${{ steps.version.outputs.debVersion }} --depends "indy-node(=${{ steps.node-version.outputs.nodeVersion }})" --verbose --no-python-dependencies --after-install ./devops/build-scripts/focal/sovtokenfees/postinst --before-remove ./devops/build-scripts/focal/sovtokenfees/prerm --exclude "*.pyo" --exclude "*.pyc" --no-python-fix-dependencies --python-bin "/usr/bin/python3" --force  sovtokenfees/
+
+          # Build the sovtoken package
+          fpm  \
+            --input-type python \
+            --output-type deb \
+            --name sovtoken \
+            --version ${{ steps.version.outputs.debVersion }} \
+            --depends "indy-node(=${{ steps.node-version.outputs.nodeVersion }})" \
+            --architecture amd64 \
+            --maintainer "Sovrin" \
+            --verbose \
+            --no-python-dependencies \
+            --no-python-fix-name \
+            --python-bin "/usr/bin/python3" \
+            --no-python-fix-dependencies \
+            --exclude "*.pyc" \
+            --exclude "*.pyo" \
+            --after-install ./devops/build-scripts/focal/sovtoken/postinst \
+            --before-remove ./devops/build-scripts/focal/sovtoken/prerm \
+            --force  \
+            sovtoken/
+
+          # Build the sovtokenfees package
+          fpm  \
+            --input-type python \
+            --output-type deb \
+            --name sovtokenfees \
+            --version ${{ steps.version.outputs.debVersion }} \
+            --architecture amd64 \
+            --maintainer "Sovrin" \
+            --verbose \
+            --no-python-fix-name  \
+            --python-bin "/usr/bin/python3" \
+            --no-python-fix-dependencies \
+            --exclude "*.pyc" \
+            --exclude "*.pyo" \
+            --after-install ./devops/build-scripts/focal/sovtokenfees/postinst \
+            --before-remove ./devops/build-scripts/focal/sovtokenfees/prerm \
+            --force  \
+            sovtokenfees/
+
           mv ./*.deb /tmp/build-output
       - name: Upload sovtoken-deb
         uses: actions/upload-artifact@v3

--- a/devops/Makefile
+++ b/devops/Makefile
@@ -38,7 +38,7 @@ ifeq ($(SRC_DIR_NAME),sovtoken)
 # 	apt: indy-plenum (stable component)
 
 FPM_P_NAME += $(PACKAGE_NAME) 
-FPM_P_DEPENDS := indy-node(=1.13.2~rc4)
+FPM_P_DEPENDS := indy-node(=1.13.2~rc5)
 FPM_ARGS := --no-python-dependencies $(FPM_ARGS) ../$(SRC_DIR_NAME)
 endif
 

--- a/sovtoken/setup.py
+++ b/sovtoken/setup.py
@@ -43,7 +43,7 @@ setup(
              '*.css', '*.ico', '*.png', 'LICENSE', 'LEGAL', 'sovtoken']},
     include_package_data=True,
 
-    install_requires=['indy-node==1.13.2.rc4'],
+    install_requires=['indy-node==1.13.2.rc5'],
 
     setup_requires=['pytest-runner'],
     extras_require={


### PR DESCRIPTION
- indy-node 1.13.2-rc5 fixes an indy-plenum version dependency descrepancy between deb and python packages.
- Update token package builds to contain python artifacts.

Signed-off-by: Wade Barnes <wade@neoterictech.ca>