### PR TITLE
Set version number to [v1.1.0]

### DIFF
--- a/sovtoken/sovtoken/metadata.json
+++ b/sovtoken/sovtoken/metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.0",
+  "version": "1.1.0",
   "author": "Sovrin",
   "license": "Apache 2.0"
 }

--- a/sovtokenfees/sovtokenfees/metadata.json
+++ b/sovtokenfees/sovtokenfees/metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.0",
+  "version": "1.1.0",
   "author": "Sovrin",
   "license": "Apache 2.0"
 }


### PR DESCRIPTION
- Set/reset version number to 1.1.0 to be true to the existing version history of the project.
- Current production release is 1.0.11.  This next version will be the first 20.04 compatible release, warranting a minor version bump.
- The 1.2.0 version contained in these files is a legacy artifact.  The metadata.json files were previously not used to define the package version.

Signed-off-by: Wade Barnes <wade@neoterictech.ca>