### PR TITLE
Update indy-node version for release.

### DIFF
--- a/sovtoken/setup.py
+++ b/sovtoken/setup.py
@@ -43,7 +43,7 @@ setup(
              '*.css', '*.ico', '*.png', 'LICENSE', 'LEGAL', 'sovtoken']},
     include_package_data=True,
 
-    install_requires=['indy-node==1.13.2.dev1678195950'],
+    install_requires=['indy-node==1.13.2'],
 
     setup_requires=['pytest-runner'],
     extras_require={


### PR DESCRIPTION
- This was missed in the previous release(s).
- It appears the indy-node release process did not successfully trigger the update PR fully.