### PR TITLE
Update action-download-artifact actions

### DIFF
--- a/.github/workflows/publishRelease.yaml
+++ b/.github/workflows/publishRelease.yaml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download sovtoken deb Artifacts from Github Action Artifacts
-        uses: dawidd6/action-download-artifact@v3
+        uses: dawidd6/action-download-artifact@v5
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
           workflow: releasepr.yaml
@@ -62,7 +62,7 @@ jobs:
           name: sovtoken-deb
           path: artifacts/sovtoken-deb
       - name: Download sovtokenfees python Artifacts from Github Action Artifacts
-        uses: dawidd6/action-download-artifact@v3
+        uses: dawidd6/action-download-artifact@v5
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
           workflow: releasepr.yaml
@@ -70,7 +70,7 @@ jobs:
           name: sovtokenfees-deb
           path: artifacts/sovtokenfees-deb
       - name: Download sovtoken python Artifacts from Github Action Artifacts
-        uses: dawidd6/action-download-artifact@v3
+        uses: dawidd6/action-download-artifact@v5
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
           workflow: releasepr.yaml
@@ -78,7 +78,7 @@ jobs:
           name: sovtoken-python
           path: artifacts/sovtoken-python
       - name: Download sovtokenfees python Artifacts from Github Action Artifacts
-        uses: dawidd6/action-download-artifact@v3
+        uses: dawidd6/action-download-artifact@v5
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
           workflow: releasepr.yaml


### PR DESCRIPTION
- Update to the latest version of action-download-artifact.
- Do not update the indy-shared-gha actions to v2 on the 20.04 branch. v2 is for the 22.04 branch.